### PR TITLE
Make assertRaises / assertWarns context managers work

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,8 +75,15 @@ A list of the available fixers can be found with the following::
     self_assert
 
 
+Note: if your tests use the context managers ``with self.assertRaises`` or
+``with self.assertWarns``, they will be transformed to ``pytest.raises`` or
+``pytest.warns`` appropriately, but because the semantics are different, any
+use of the output value from the context managers (e.g. the ``x`` in
+``with pytest.raises(ValueError) as x:``) will be wrong and will require
+manual adjustment after the fact.
+
 .. _`lib2to3 documentation`: http://docs.python.org/library/2to3.html
-.. _pytest: http://www.python.org/dev/peps/pep-0008/
+.. _pytest: https://pytest.org/latest/
 
 
 ..

--- a/tests/fixtures/self_assert/assertRaises_in.py
+++ b/tests/fixtures/self_assert/assertRaises_in.py
@@ -12,3 +12,12 @@ class TestRaises(TestCase):
 
     def test_args_kwargs(self):
         self.assertRaises(RunTimeError, someFunc, 1,2,3, foo=42, bar=43)
+
+    def test_context_manager(self):
+        with self.assertRaises(RunTimeError):
+            someFunc()
+
+    def test_context_manager_var(self):
+        with self.assertRaises(RunTimeError) as ctx:
+            someFunc()
+        assert ctx.exception

--- a/tests/fixtures/self_assert/assertRaises_out.py
+++ b/tests/fixtures/self_assert/assertRaises_out.py
@@ -16,3 +16,12 @@ class TestRaises(TestCase):
     def test_args_kwargs(self):
         with pytest.raises(RunTimeError):
             someFunc(1,2,3, foo=42, bar=43)
+
+    def test_context_manager(self):
+        with pytest.raises(RunTimeError):
+            someFunc()
+
+    def test_context_manager_var(self):
+        with pytest.raises(RunTimeError) as ctx:
+            someFunc()
+        assert ctx.exception

--- a/unittest2pytest/fixes/fix_self_assert.py
+++ b/unittest2pytest/fixes/fix_self_assert.py
@@ -109,15 +109,25 @@ def RaisesOp(context, exceptionClass, indent, kws, arglist):
     arglist = [a.clone() for a in arglist.children[4:]]
     if arglist:
         arglist[0].prefix=""
+
+    func = None
+
     # :fixme: this uses hardcoded parameter names, which may change
     if 'callableObj' in kws:
-        suite = Call(kws['callableObj'], arglist)
+        func = kws['callableObj']
     elif 'callable_obj' in kws:
-        suite = Call(kws['callable_obj'], arglist)
-    elif kws['args']: # any arguments assigned to `*args`
-        suite = Call(kws['args'][0], arglist)
+        func = kws['callable_obj']
+    elif kws['args']:  # any arguments assigned to `*args`
+        func = kws['args'][0]
     else:
-        raise NotImplementedError('with %s is not implemented' % context)
+        func = None
+
+    if func is None:
+        # Context manager
+        return Node(syms.with_stmt, [with_item])
+
+    suite = Call(func, arglist)
+
     suite.prefix = indent + (4 * " ")
     return Node(syms.with_stmt,
                 [Name('with'),


### PR DESCRIPTION
Fixes #4. Note that since the semantics of what e.g. `assertRaises` captures is different to what `pytest.raises` captures, they can't easily be converted. It's recommended users manually fix up any cases after the fact - added a note to the README to indicate this.

Also fixed the link to pytest in the README, it was pointing to PEP8.
