### PR TITLE
Fix tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 *.egg-link
 
 /nosetests.xml
+/.cache
 /.coverage
 /.tox
 /.achievements

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include CHANGES.rst
+include COPYING-GPLv3.txt
+include README.rst
+
+recursive-include tests *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]


### PR DESCRIPTION
Fixes #6. Add a MANIFEST.in to ensure that all relevant files are copied into the package. Also git ignore the .cache directory that new pytest versions create.