### PR TITLE
Don't add " \" on blank lines before an assert statement

### DIFF
--- a/tests/fixtures/self_assert/assertDictEqual_in.py
+++ b/tests/fixtures/self_assert/assertDictEqual_in.py
@@ -19,3 +19,5 @@ class TestDictEqual(TestCase):
             {'b': 2},
             "This is wrong!",
         )
+
+        self.assertDictEqual(100, klm)

--- a/tests/fixtures/self_assert/assertDictEqual_out.py
+++ b/tests/fixtures/self_assert/assertDictEqual_out.py
@@ -17,3 +17,5 @@ class TestDictEqual(TestCase):
             } == \
             {'b': 2}, \
             "This is wrong!"
+
+        assert 100 == klm

--- a/tests/fixtures/self_assert/assertEqual_in.py
+++ b/tests/fixtures/self_assert/assertEqual_in.py
@@ -18,6 +18,7 @@ class TestAssertEqual(TestCase):
     def test_line_wrapping(self):
         self.assertEqual(True, False, 'This will fail %s' %
                 'always')
+
         self.assertEqual(
 
                          'abc'

--- a/tests/fixtures/self_assert/assertEqual_out.py
+++ b/tests/fixtures/self_assert/assertEqual_out.py
@@ -18,6 +18,7 @@ class TestAssertEqual(TestCase):
     def test_line_wrapping(self):
         assert True == False, 'This will fail %s' % \
                 'always'
+
         assert 'abc' \
                          .replace(
                                   'abc'

--- a/tests/fixtures/self_assert/assertSequenceEqual_in.py
+++ b/tests/fixtures/self_assert/assertSequenceEqual_in.py
@@ -35,3 +35,5 @@ class TestSequenceEqual(TestCase):
             "This is wrong!",
             list
         )
+
+        self.assertSequenceEqual(100, klm)

--- a/tests/fixtures/self_assert/assertSequenceEqual_out.py
+++ b/tests/fixtures/self_assert/assertSequenceEqual_out.py
@@ -32,3 +32,5 @@ class TestSequenceEqual(TestCase):
             ] == \
             ['b'], \
             "This is wrong!"
+
+        assert 100 == klm

--- a/tests/fixtures/self_assert/assertSetEqual_in.py
+++ b/tests/fixtures/self_assert/assertSetEqual_in.py
@@ -19,3 +19,5 @@ class TestSetEqual(TestCase):
             set(['b']),
             "This is wrong!",
         )
+
+        self.assertSetEqual(100, klm)

--- a/tests/fixtures/self_assert/assertSetEqual_out.py
+++ b/tests/fixtures/self_assert/assertSetEqual_out.py
@@ -18,3 +18,5 @@ class TestSetEqual(TestCase):
             ]) == \
             set(['b']), \
             "This is wrong!"
+
+        assert 100 == klm

--- a/tests/fixtures/self_assert/assertTupleEqual_in.py
+++ b/tests/fixtures/self_assert/assertTupleEqual_in.py
@@ -19,3 +19,5 @@ class TestTupleEqual(TestCase):
             ('b',),
             "This is wrong!",
         )
+
+        self.assertTupleEqual(100, klm)

--- a/tests/fixtures/self_assert/assertTupleEqual_out.py
+++ b/tests/fixtures/self_assert/assertTupleEqual_out.py
@@ -17,3 +17,5 @@ class TestTupleEqual(TestCase):
             ) == \
             ('b',), \
             "This is wrong!"
+
+        assert 100 == klm

--- a/unittest2pytest/fixes/fix_self_assert.py
+++ b/unittest2pytest/fixes/fix_self_assert.py
@@ -341,7 +341,6 @@ class FixSelfAssert(BaseFix):
                            _method_map[method](*required_args, kws=argsdict)])
         if argsdict.get('msg', None) is not None:
             n_stmt.children.extend((Name(','), argsdict['msg']))
-        n_stmt.prefix = node.prefix
 
         def fix_line_wrapping(x):
             for c in x.children:
@@ -352,5 +351,7 @@ class FixSelfAssert(BaseFix):
                     c.prefix = c.prefix.replace('\n', ' \\\n')
                 fix_line_wrapping(c)
         fix_line_wrapping(n_stmt)
+        # the prefix should be set only after fixing line wrapping because it can contain a '\n'
+        n_stmt.prefix = node.prefix
 
         return n_stmt


### PR DESCRIPTION
The last changes to maintain line wrapping is broken when there is a
blank line before an assert statement.