### PR TITLE
Parenthesize some arguments

### DIFF
--- a/tests/fixtures/self_assert/assertEqual_in.py
+++ b/tests/fixtures/self_assert/assertEqual_in.py
@@ -28,3 +28,8 @@ class TestAssertEqual(TestCase):
                          'def',
                          msg='Wrap %s' %
                          'everything')
+
+    def test_expression_as_argument(self):
+        self.assertEqual(abc not in self.data, True)
+        self.assertEqual(abc in self.data, not contains)
+        self.assertEqual(contains, not contains)

--- a/tests/fixtures/self_assert/assertEqual_out.py
+++ b/tests/fixtures/self_assert/assertEqual_out.py
@@ -26,3 +26,8 @@ class TestAssertEqual(TestCase):
                          'def', \
                          'Wrap %s' % \
                          'everything'
+
+    def test_expression_as_argument(self):
+        assert (abc not in self.data) == True
+        assert (abc in self.data) == (not contains)
+        assert contains == (not contains)

--- a/tests/fixtures/self_assert/assertFalse_in.py
+++ b/tests/fixtures/self_assert/assertFalse_in.py
@@ -13,3 +13,8 @@ class TestAssertFalse(TestCase):
     def test_message(self):
         self.assertFalse(123+z, msg=error_message)
         self.assertFalse(xxx+z, 'This is wrong!')
+
+    def test_expression_as_argument(self):
+        self.assertFalse(abc not in self.data)
+        self.assertFalse(abc in self.data)
+        self.assertFalse(not contains)

--- a/tests/fixtures/self_assert/assertFalse_out.py
+++ b/tests/fixtures/self_assert/assertFalse_out.py
@@ -13,3 +13,8 @@ class TestAssertFalse(TestCase):
     def test_message(self):
         assert not 123+z, error_message
         assert not xxx+z, 'This is wrong!'
+
+    def test_expression_as_argument(self):
+        assert not (abc not in self.data)
+        assert not (abc in self.data)
+        assert not (not contains)

--- a/tests/fixtures/self_assert/assertTrue_in.py
+++ b/tests/fixtures/self_assert/assertTrue_in.py
@@ -13,3 +13,8 @@ class TestAssertTrue(TestCase):
     def test_message(self):
         self.assertTrue(123+z, msg='This is wrong!')
         self.assertTrue(xxx+z, error_message)
+
+    def test_expression_as_argument(self):
+        self.assertTrue(abc not in self.data)
+        self.assertTrue(abc in self.data)
+        self.assertTrue(not contains)

--- a/tests/fixtures/self_assert/assertTrue_out.py
+++ b/tests/fixtures/self_assert/assertTrue_out.py
@@ -13,3 +13,8 @@ class TestAssertTrue(TestCase):
     def test_message(self):
         assert 123+z, 'This is wrong!'
         assert xxx+z, error_message
+
+    def test_expression_as_argument(self):
+        assert abc not in self.data
+        assert abc in self.data
+        assert not contains


### PR DESCRIPTION
When arguments are formed by in, not and other keywords, the evaluation
of converted statement might have a different precedence or even
generate a syntax error.
E.g. assert True == not False