### PR TITLE
Allow the usage of `python setup.py install`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,4 +71,6 @@ setup(
         "Programming Language :: Python",
         "Topic :: Software Development",
         "Topic :: Utilities",
-    ])
+    ],
+    zip_safe=False
+)


### PR DESCRIPTION
Added `zip_safe=False` to `setup.py` as a suggestion by @RonnyPfannschmidt. 