### PR TITLE
Fixed bug converting asserts that use a regex.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@
 /nosetests.xml
 /.cache
 /.coverage
+/.pytest_cache
 /.tox
 /.achievements
 /.installed.cfg

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 v0.4 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fixed assertRaisesRegex, assertRaisesRegexp and assertWarnsRegex.  The regex
+  was getting replaced with an undefined variable `pattern`.
+- Made assertRaisesRegex, assertRaisesRegexp and assertWarnsRegex use the
+  `match` kwarg in `pytest.raises` instead of creating a variable with the
+  context manager and doing an assert on `re.search`.
 
 
 v0.3 (2016-07-26)

--- a/tests/fixtures/self_assert/assertRaisesRegex_out.py
+++ b/tests/fixtures/self_assert/assertRaisesRegex_out.py
@@ -1,46 +1,38 @@
 # required-method: assertRaisesRegex
 
 import pytest
-import re
 class TestRaises(TestCase):
     def test_simple(self):
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc()
-        assert re.search("text .* match", excinfo.value)
 
     def test_simple_with_newlines(self):
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc()
-        assert re.search("text .* match", excinfo.value)
 
     def test_args(self):
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc(1,2,3)
-        assert re.search("text .* match", excinfo.value)
 
     def test_kwargs(self):
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc(foo=42, bar=43)
-        assert re.search("text .* match", excinfo.value)
 
     def test_context_manager(self):
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc('foo', None)
-        assert re.search("text .* match", excinfo.value)
 
     def test_args_kwargs(self):
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc(1,2,3, foo=42, bar=43)
-        assert re.search("text .* match", excinfo.value)
 
     def test_args_kwargs_with_newlines(self):
         # TODO: Newlines within arguments are not handled yet.
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc(1,
             2,3,
             foo=42,
             bar=43)
-        assert re.search("text .* match", excinfo.value)
 
     def test_lambda(self):
         with pytest.raises(RunTimeError):

--- a/tests/fixtures/self_assert/assertRaisesRegexp_out.py
+++ b/tests/fixtures/self_assert/assertRaisesRegexp_out.py
@@ -1,46 +1,38 @@
 # required-method: assertRaisesRegexp
 
 import pytest
-import re
 class TestRaises(TestCase):
     def test_simple(self):
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc()
-        assert re.search("text .* match", excinfo.value)
 
     def test_simple_with_newlines(self):
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc()
-        assert re.search("text .* match", excinfo.value)
 
     def test_args(self):
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc(1,2,3)
-        assert re.search("text .* match", excinfo.value)
 
     def test_kwargs(self):
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc(foo=42, bar=43)
-        assert re.search("text .* match", excinfo.value)
 
     def test_context_manager(self):
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc('foo', None)
-        assert re.search("text .* match", excinfo.value)
 
     def test_args_kwargs(self):
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc(1,2,3, foo=42, bar=43)
-        assert re.search("text .* match", excinfo.value)
 
     def test_args_kwargs_with_newlines(self):
         # TODO: Newlines within arguments are not handled yet.
-        with pytest.raises(RunTimeError) as excinfo:
+        with pytest.raises(RunTimeError, match="text .* match"):
             someFunc(1,
             2,3,
             foo=42,
             bar=43)
-        assert re.search("text .* match", excinfo.value)
 
     def test_lambda(self):
         with pytest.raises(RunTimeError):

--- a/tests/fixtures/self_assert/assertWarnsRegex_in.py
+++ b/tests/fixtures/self_assert/assertWarnsRegex_in.py
@@ -12,3 +12,7 @@ class TestWarns(TestCase):
 
     def test_args_kwargs(self):
         self.assertWarnsRegex(RunTimeError, pattern, someFunc, 1,2,3, foo=42, bar=43)
+
+    def test_context_manager(self):
+        with self.assertWarnsRegex(RunTimeError, pattern):
+            someFunc(1, 2, 3)

--- a/tests/fixtures/self_assert/assertWarnsRegex_out.py
+++ b/tests/fixtures/self_assert/assertWarnsRegex_out.py
@@ -1,24 +1,23 @@
 # required-method: assertWarnsRegex
 
 import pytest
-import re
 class TestWarns(TestCase):
     def test_simple(self):
-        with pytest.warns(RunTimeError) as record:
+        with pytest.warns(RunTimeError, match=pattern):
             someFunc()
-        assert re.search(pattern, record.value)
 
     def test_args(self):
-        with pytest.warns(RunTimeError) as record:
+        with pytest.warns(RunTimeError, match=pattern):
             someFunc(1,2,3)
-        assert re.search(pattern, record.value)
 
     def test_kwargs(self):
-        with pytest.warns(RunTimeError) as record:
+        with pytest.warns(RunTimeError, match=pattern):
             someFunc(foo=42, bar=43)
-        assert re.search(pattern, record.value)
 
     def test_args_kwargs(self):
-        with pytest.warns(RunTimeError) as record:
+        with pytest.warns(RunTimeError, match=pattern):
             someFunc(1,2,3, foo=42, bar=43)
-        assert re.search(pattern, record.value)
+
+    def test_context_manager(self):
+        with pytest.warns(RunTimeError, match=pattern):
+            someFunc(1, 2, 3)

--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,4 @@ envlist = py27, py33, py34, py35, py36
 [testenv]
 deps =
     pytest
-commands = py.test
+commands = pytest {posargs}

--- a/unittest2pytest/fixes/fix_self_assert.py
+++ b/unittest2pytest/fixes/fix_self_assert.py
@@ -125,7 +125,7 @@ def RaisesOp(context, exceptionClass, indent, kws, arglist, node):
     # Add match keyword arg to with statement if an expected regex was provided.
     # In py27 the keyword is `expected_regexp`, in py3 is `expected_regex`
     if 'expected_regex' in kws or 'expected_regexp' in kws:
-        expected_regex = kws.get('expected_regex', kws['expected_regexp'])
+        expected_regex = kws.get('expected_regex', kws.get('expected_regexp'))
         args.append(String(', '))
         args.append(
             KeywordArg(Name('match'), String(expected_regex.value)))

--- a/unittest2pytest/fixes/fix_self_assert.py
+++ b/unittest2pytest/fixes/fix_self_assert.py
@@ -121,7 +121,15 @@ def AlmostOp(places_op, delta_op, first, second, kws):
 
 def RaisesOp(context, exceptionClass, indent, kws, arglist, node):
     exceptionClass.prefix = ""
-    with_item = Call(Name(context), [exceptionClass])
+    args = [exceptionClass]
+    # Add match keyword arg to with statement if an expected regex was provided.
+    # In py27 the keyword is `expected_regexp`, in py3 is `expected_regex`
+    if 'expected_regex' in kws or 'expected_regexp' in kws:
+        expected_regex = kws.get('expected_regex', kws['expected_regexp'])
+        args.append(String(', '))
+        args.append(
+            KeywordArg(Name('match'), String(expected_regex.value)))
+    with_item = Call(Name(context), args)
     with_item.prefix = " "
     args = []
     arglist = [a.clone() for a in arglist.children[4:]]
@@ -167,19 +175,6 @@ def RaisesRegexOp(context, designator, exceptionClass, expected_regex,
     del arglist[2:4] # remove pattern and comma
     arglist = Node(syms.arglist, arglist)
     with_stmt = RaisesOp(context, exceptionClass, indent, kws, arglist, node)
-    with_stmt.insert_child(2, Name('as', prefix=" "))
-    with_stmt.insert_child(3, Name(designator, prefix=" "))
-
-    def make_assert(pattern, designator):
-        # Build an assert stmt to match the message like this:
-        #   assert re.search("text .* match", excinfo.value)
-        pattern.prefix = ""
-        node = Node(syms.assert_stmt,
-                    [Name('assert '),
-                     Call(Name('re.search'),
-                          [pattern, Name(', %s.value' % designator)])])
-        node.prefix = indent
-        return node
 
     # if this is already part of a with statement we need to insert re.search
     # after the last leaf with content
@@ -189,14 +184,9 @@ def RaisesRegexOp(context, designator, exceptionClass, expected_regex,
             if leaf.value.strip():
                 break
         i = leaf.parent.children.index(leaf)
-        leaf.parent.insert_child(i + 1, Newline())
-        leaf.parent.insert_child(i + 2, make_assert(pattern, designator))
         return with_stmt
     else:
-        return Node(syms.suite,
-                    [with_stmt,
-                     Newline(),
-                     make_assert(pattern, designator)])
+        return Node(syms.suite, [with_stmt])
 
 
 def add_import(import_name, node):
@@ -333,16 +323,16 @@ for a, o in list(_method_aliases.items()):
 
 """
 Node(power,
-     [Leaf(1, u'self'), 
+     [Leaf(1, u'self'),
       Node(trailer,
-           [Leaf(23, u'.'), 
+           [Leaf(23, u'.'),
             Leaf(1, u'assertEqual')]),
       Node(trailer,
-           [Leaf(7, u'('), 
-            Node(arglist, 
-                 [Leaf(1, u'abc'), 
-                  Leaf(12, u','), 
-                  Leaf(3, u"'xxx'")]), 
+           [Leaf(7, u'('),
+            Node(arglist,
+                 [Leaf(1, u'abc'),
+                  Leaf(12, u','),
+                  Leaf(3, u"'xxx'")]),
             Leaf(8, u')')])])
 
 Node(power,
@@ -350,19 +340,19 @@ Node(power,
       Node(trailer,
            [Leaf(23, u'.'),
             Leaf(1, u'assertAlmostEqual')]),
-      Node(trailer, 
+      Node(trailer,
            [Leaf(7, u'('),
-            Node(arglist, 
+            Node(arglist,
                  [Leaf(2, u'100'),
                   Leaf(12, u','),
                   Leaf(1, u'klm'),
                   Leaf(12, u','),
-                Node(argument, 
+                Node(argument,
                      [Leaf(1, u'msg'),
                       Leaf(22, u'='),
                       Leaf(3, u'"Message"')]),
                   Leaf(12, u','),
-                  Node(argument, 
+                  Node(argument,
                        [Leaf(1, u'places'),
                         Leaf(22, u'='),
                         Leaf(2, u'1')])]),
@@ -461,7 +451,8 @@ class FixSelfAssert(BaseFix):
         # add necessary imports
         if 'Raises' in method or 'Warns' in method:
             add_import('pytest', node)
-        if 'Regex' in method:
+        if ('Regex' in method and not 'Raises' in method and
+                not 'Warns' in method):
             add_import('re', node)
 
         return n_stmt


### PR DESCRIPTION
Also changed the conversion to pass a kwarg to match instead of
capturing the exception with the context manager and doing a re.search
against it for asserting the exception message.

Fixes #23 

```
unittest2pytest -f self_assert test.py
RefactoringTool: Refactored test.py
--- test.py	(original)
+++ test.py	(refactored)
@@ -1,17 +1,18 @@
 import warnings
 from unittest import TestCase
+import pytest


 class FooTestCase(TestCase):

     def test_raisesregexp(self):
-        with self.assertRaisesRegexp(ValueError, 'Foo'):
+        with pytest.raises(ValueError, match='Foo'):
             raise ValueError('Foo')

     def test_raisesregex(self):
-        with self.assertRaisesRegex(ValueError, 'Bar'):
+        with pytest.raises(ValueError, match='Bar'):
             raise ValueError('Bar')

     def test_warnsregex(self):
-        with self.assertWarnsRegex(DeprecationWarning, 'Foobar'):
+        with pytest.warns(DeprecationWarning, match='Foobar'):
             warnings.warn('Foobar yada yada', DeprecationWarning)
RefactoringTool: Files that need to be modified:
RefactoringTool: test.py
```