### PR TITLE
Set consistent GPL-3.0+ classifier in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "Development Status :: 4 - Beta",
         "Environment :: Console",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",


### PR DESCRIPTION
In setup.py we have:
- a GPL-3.0+ "license" 
- an LGPL-3.0+ "qualifiers" 
Everywhere else we have a proper GPL notice.
This makes the license classifier consistent with the licensing

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>