### PR TITLE
Use `pytest.approx` in `fixes.AlmostOp`

### DIFF
--- a/unittest2pytest/fixes/fix_self_assert.py
+++ b/unittest2pytest/fixes/fix_self_assert.py
@@ -114,21 +114,14 @@ def SequenceEqual(left, right, kws):
 
 
 def AlmostOp(places_op, delta_op, first, second, kws):
-    first.prefix =  ""
+    first.prefix = ""
     second.prefix = ""
     first = parenthesize_expression(first)
     second = parenthesize_expression(second)
-    abs_op = Call(Name('abs'),
-                  [Node(syms.factor, [first, Name('-'), second])])
-    if kws.get('delta', None) is not None:
-        # delta
-        return CompOp(delta_op, abs_op, kws['delta'], {})
+    if kws.get('places') is not None:
+        return CompOp(places_op, first, Call(Name("approx"), [second, kws.get('places')]), {})
     else:
-        # `7` is the default in unittest.TestCase.assertAlmostEqual
-        places = kws['places'] or Number(7)
-        places.prefix = " "
-        round_op = Call(Name('round'), (abs_op, Comma(), places))
-        return CompOp(places_op, round_op, Number(0), {})
+        return CompOp(places_op, first, Call(Name("approx"), [second]), {})
 
 
 def RaisesOp(context, exceptionClass, indent, kws, arglist, node):


### PR DESCRIPTION
Closes #63.

Change `AlmostOp()` to rewrite `self.assertAlmostEqual(3, 3.0)` to `3 == approx(3.0)` instead of `round(abs(3 - 3.0), 7) == 0`.

Still needs tests. Also currently requires adding `from pytest import approx` though that can be done with something like `isort --add-import 'from pytest import approx' $(git status -s | cut -c4-)`.

Here's an example diff generated by the new `AlmostOp()`:

![Screenshot 2023-01-19 at 21 09 25](https://user-images.githubusercontent.com/30958850/213622645-41a1b98c-7868-4cd8-a7c4-d9dcbe10accc.png)
