### PR TITLE
GitHub Actions: Add Python 3.12 and 3.13 to the testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         # Python >= 3.13 will fail with `ModuleNotFoundError: No module named 'lib2to3'`
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest]  # , windows-latest]  # Windows tests will fail.
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        #exclude:
-        #  # TODO Fix these versions on Windows
-        #  - {os: windows-latest, python-version: "3.8"}
-        #  - {os: windows-latest, python-version: "3.9"}
-        #  - {os: windows-latest, python-version: "3.10"}
-        #  - {os: windows-latest, python-version: "3.11"}
+        # Python >= 3.13 will fail with `ModuleNotFoundError: No module named 'lib2to3'`
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, macos-latest]  # , windows-latest]  # Windows tests will fail.
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,21 +11,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-          # TODO Fix these versions on Windows
-          - {os: windows-latest, python-version: "3.7"}
-          - {os: windows-latest, python-version: "3.8"}
-          - {os: windows-latest, python-version: "3.9"}
-          - {os: windows-latest, python-version: "3.10"}
-          - {os: windows-latest, python-version: "3.11"}
+        #exclude:
+        #  # TODO Fix these versions on Windows
+        #  - {os: windows-latest, python-version: "3.8"}
+        #  - {os: windows-latest, python-version: "3.9"}
+        #  - {os: windows-latest, python-version: "3.10"}
+        #  - {os: windows-latest, python-version: "3.11"}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -35,7 +34,7 @@ jobs:
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Python >=3.9 is now required.
 
 
 0.4 (2019-06-30)

--- a/setup.py
+++ b/setup.py
@@ -65,14 +65,13 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development",
         "Topic :: Utilities",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     zip_safe=False
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38, py39, py310, py311
+envlist = py39, py310, py311, py312
 
 [testenv]
 deps =


### PR DESCRIPTION
https://devguide.python.org/versions

Python >= 3.13 will fail with `ModuleNotFoundError: No module named 'lib2to3'`