### PR TITLE
GitHub Actions: Remove the deprecated `set-output` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache
         uses: actions/cache@v4


### PR DESCRIPTION
```diff
      - name: Get pip cache dir
        id: pip-cache
        run: |
-         echo "::set-output name=dir::$(pip cache dir)"
+         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
```
Fixes warnings at bottom right of
https://github.com/pytest-dev/unittest2pytest/actions/runs/12145268432

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands