### PR TITLE
Allow non-string keys in assertDictContainsSubset

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Changelog
 
 - Python >=3.9 is now required.
 
+- Allow non-string keys when translating ``assertDictContainsSubset`` (`#54`_).
+
+.. _#54: https://github.com/pytest-dev/unittest2pytest/issues/54
+
 
 0.4 (2019-06-30)
 ----------------

--- a/tests/fixtures/self_assert/assertDictContainsSubset_out.py
+++ b/tests/fixtures/self_assert/assertDictContainsSubset_out.py
@@ -2,19 +2,19 @@
 
 class TestDictEqual(TestCase):
     def test_simple(self):
-        assert dict(superset, **{'a: 1'}) == superset
+        assert {**superset, **{'a: 1'}} == superset
 
     def test_simple_msg(self):
-        assert dict({'a: 1'}, **subset) == {'a: 1'}, "This is wrong!"
+        assert {**{'a: 1'}, **subset} == {'a: 1'}, "This is wrong!"
 
     def test_simple_msg2(self):
-        assert dict({'a: 1'}, **subset) == {'a: 1'}, "This is wrong!"
+        assert {**{'a: 1'}, **subset} == {'a: 1'}, "This is wrong!"
 
     def test_line_wrapping(self):
-        assert dict({
+        assert {**{
                 'a': 1,
                 'b': 2,
-            }, **{'b': 2}) == {
+            }, **{'b': 2}} == {
                 'a': 1,
                 'b': 2,
             }, \

--- a/unittest2pytest/fixes/fix_self_assert.py
+++ b/unittest2pytest/fixes/fix_self_assert.py
@@ -275,7 +275,7 @@ _method_map = {
     'assertTupleEqual':     partial(CompOp, '=='),
     'assertSequenceEqual':  SequenceEqual,
 
-    'assertDictContainsSubset': partial(DualOp, 'dict(\2, **\1) == \2'),
+    'assertDictContainsSubset': partial(DualOp, '{**\2, **\1} == \2'),
     'assertItemsEqual':         partial(DualOp, 'sorted(\1) == sorted(\2)'),
 
     'assertAlmostEqual':    partial(AlmostOp, "==", "<"),


### PR DESCRIPTION
Rebased from #55.

Fixes #54.