### PR TITLE
[codex] Fix line wrapping for commented implicit strings

### DIFF
--- a/tests/fixtures/self_assert/assertEqual_in.py
+++ b/tests/fixtures/self_assert/assertEqual_in.py
@@ -32,6 +32,11 @@ class TestAssertEqual(TestCase):
                          msg='Wrap %s' %
                          'everything')
 
+    def test_implicit_string_with_comment(self):
+        self.assertEqual('a'
+                         # keep this comment
+                         'b', actual)
+
     def test_expression_as_argument(self):
         self.assertEqual(abc not in self.data, True)
         self.assertEqual(abc in self.data, not contains)

--- a/tests/fixtures/self_assert/assertEqual_out.py
+++ b/tests/fixtures/self_assert/assertEqual_out.py
@@ -30,6 +30,11 @@ class TestAssertEqual(TestCase):
                          'Wrap %s' % \
                          'everything'
 
+    def test_implicit_string_with_comment(self):
+        assert ('a'
+                         # keep this comment
+                         'b' == actual)
+
     def test_expression_as_argument(self):
         assert (abc not in self.data) == True
         assert (abc in self.data) == (not contains)

--- a/unittest2pytest/fixes/fix_self_assert.py
+++ b/unittest2pytest/fixes/fix_self_assert.py
@@ -100,6 +100,21 @@ def parenthesize_expression(value):
     return value
 
 
+def has_comment_prefix(value):
+    return any("#" in leaf.prefix for leaf in value.leaves())
+
+
+def parenthesize_assert_expression_with_comments(assert_stmt):
+    if assert_stmt.type != syms.assert_stmt:
+        return
+    expression = assert_stmt.children[1]
+    if has_comment_prefix(expression):
+        parenthesized = parenthesize(expression.clone())
+        parenthesized.prefix = expression.prefix
+        parenthesized.children[1].prefix = ""
+        assert_stmt.set_child(1, parenthesized)
+
+
 def fill_template(template, *args):
     parts = TEMPLATE_PATTERN.findall(template)
     kids = []
@@ -475,6 +490,8 @@ class FixSelfAssert(BaseFix):
             )
         if argsdict.get("msg", None) is not None and method != "fail":
             n_stmt.children.extend((Name(","), argsdict["msg"]))
+
+        parenthesize_assert_expression_with_comments(n_stmt)
 
         def fix_line_wrapping(x):
             for c in x.children:


### PR DESCRIPTION
## Summary

Fixes conversion of `self.assertEqual(...)` calls when an implicitly concatenated multi-line string contains an inline comment. The previous line-wrapping step could add backslash continuations to comment lines, producing invalid Python.

This changes the fixer to wrap generated assert expressions in parentheses when the expression contains comment-prefixed leaves, allowing Python implicit continuation to preserve comments safely.

## Validation

- `.venv/bin/python -m pytest -q`
- `git diff --check`

Local result: `36 passed, 1 skipped, 16 warnings`.
